### PR TITLE
History Fix for No Signal State

### DIFF
--- a/BlinkinFirmware/BlinkinFirmware.ino
+++ b/BlinkinFirmware/BlinkinFirmware.ino
@@ -184,8 +184,15 @@ void loop() {
 
 ISR(TIMER1_COMPA_vect) { //timer1 interrupt 1Hz
 //ISR(TIMER1_OVF_vect){
-  currentPattern = 13;
+  //currentPattern = 13;
   //gPatterns[currentPattern]();
+
+//  for (int i = 0 ; i<patternHistory.capacity() ; i++){
+//      patternHistory.unshift(13);
+//  }
+
+  patternHistory.unshift(14);
+  
   updatedLEDs = false;
   inPulse = false;
   //TCNT1  = 0;//initialize counter value to 0, reset heatbeat


### PR DESCRIPTION
Adding history broke the no signal error state.  Needed to push the "no
signal" pattern to the history or it will never update! Fixed now.