### PR TITLE
Prevent unexpected execution of commands

### DIFF
--- a/interrupt.ino
+++ b/interrupt.ino
@@ -51,28 +51,12 @@ void ISRfalling()
   uint16_t pwm_value = TCNT1 - prev_time;
 
   //TCNT1*0.0000005 = pulse width (seconds)
-  if ((pwm_value <= 4000) && (pwm_value >= 1990)) {
-    if (commandSeq == false) {
-      patternHistory.unshift((byte)constrain(map(pwm_value, 2000, 4000, 0, 100),0,99) ); //4000 is 2000ms and 1000 is 1000ms
-    }
-    else {
-      gCommands[currCommand](map(pwm_value, 2000, 4000, 0, 99));
-      
-      commandSeq = false;
-      setStatusRun();
-    }
+  if (pwm_value <= 4000 && pwm_value >= 2000) {
+    patternHistory.unshift((byte)constrain(map(pwm_value, 2000, 4000, 0, 100),0,99)); //4000 is 2000ms and 1000 is 1000ms
+  } else if(pwm_value >= 4200 && pwm_value <= 4400) {
+    patternHistory.unshift((byte)(constrain(map(pwm_value, 4200, 4400, 0, 10), 0, 9) + 100));
   }
-  else if ((pwm_value >= 4200) && (pwm_value <= 4400)) {
-    if ((inSetup == false)) {
 
-        commandSeq = true;   
-          
-        // Indicate Command mode signal detected    
-        setStatusCommand();
-        
-        currCommand = constrain(map(pwm_value, 4200, 4401, 0, 10), 0, 9);
-    }
-  }
 
   prev_time = 0;
   inPulse = false;


### PR DESCRIPTION
There are some undocumented "commands" from 2100-2200 us that allow for control of the Blinkin beyond just changing the pattern. Some of the commands can do include disabling the LEDs and changing strips, but they have a problem. To trigger a command only one pulse of the correct length is required. This means that an extraneous pulse can cause the Blinkin to do random things and such as turning off the strip. On my robot I have noticed this happening at least once and sometimes as often as five times in an hour. A forum post describing the issue can be found [here](https://www.chiefdelphi.com/t/rev-blinkin-resetting-strip-mode-randomly/432510/11). I made a
[sample Arduino sketch](https://github.com/user-attachments/files/18470598/SingleShot.zip) to demonstrate the issue.

This was already fixed for changing patterns as they require 3 pulses of the same length to trigger, so I implemented the same system for commands. 

See [PWM_0_Command.ino](https://github.com/REVrobotics/Blinkin-Firmware/blob/e059c7fcede59b9580d0c4edefce3940415f2a81/PWM_0_Command.ino) for the current implementation of of the commands and [interrupt.ino](https://github.com/REVrobotics/Blinkin-Firmware/blob/e059c7fcede59b9580d0c4edefce3940415f2a81/interrupt.ino) for where they get called. 